### PR TITLE
Readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@
 12. Copy the console output database_name and database_id
 13. Go to `wrangler.toml` and change `database_name` and `database_id`.
 14. Go to `drizzle.config.ts` and change db name in `dbName`.
-15. Go to `package.json` and change db name in `db:push:*`.
+15. Go to `package.json` and change db name in `db:push:*` and `db:backup:prod`.
 16. Generate and migrate the schema to dev or prod db: `bun run db:migrate; bun run db:push:dev; bun run db:push:prod`
 17. Develop on local with `bun run dev` 
 18. Deploy to prod  with `bun run deploy` 

--- a/README.md
+++ b/README.md
@@ -33,22 +33,21 @@
 
 ### ⬇️ Installation
 
-1. Install prerequisites Node.js or Bun `curl -fsSL https://bun.sh/install | bash`
-2. Clone to localhost or server `git clone https://github.com/vtempest/docs-stack-starter`
-3. CD to project directory `cd docs-stack-starter`
-4. Install dependencies `bun install`
-5. `mv .env.example .env ; mv wrangler.example.toml wrangler.toml` and set the domain and API keys in `.env` 
-6. Auth providers, get id/secret from [Google](https://console.cloud.google.com/apis/credentials) 
-7. Set OAuth origin `http://localhost` and `http://localhost:5173` on local or `https://domain.com` on server
-8. Set redirect `http://localhost:5173/auth/oauth/google/callback` or `https://api.domain.com/auth/oauth/google/callback`
-9. For email auth, get API from [Resend](https://resend.com/api-keys) mailer and verify domain
-10. Log in with your Cloudflare account by running: `bunx wrangler login`
-11. Create your D1 database via dashboard or with `bunx wrangler d1 create my-db-prod`
-12. Copy the console output database_name and database_id
+1. Install prerequisites Node.js or Bun `curl -fsSL https://bun.sh/install | bash`.
+2. Clone to localhost or server `git clone https://github.com/vtempest/docs-stack-starter`.
+3. CD to project directory `cd docs-stack-starter`.
+4. Install dependencies `bun install`.
+5. `mv .env.example .env ; mv wrangler.example.toml wrangler.toml` and set the domain and API keys in `.env`.
+6. Auth providers, get id/secret from [Google](https://console.cloud.google.com/apis/credentials).
+7. Set OAuth origin `http://localhost` and `http://localhost:5173` on local or `https://domain.com` on server.
+8. Set redirect `http://localhost:5173/auth/oauth/google/callback` or `https://api.domain.com/auth/oauth/google/callback`.
+9. For email auth, get API from [Resend](https://resend.com/api-keys) mailer and verify domain.
+10. Log in with your Cloudflare account by running: `bunx wrangler login`.
+11. Create your D1 database via dashboard or with `bunx wrangler d1 create my-db-prod`.
+12. Copy the console output database_name and database_id.
 13. Go to `wrangler.toml` and change `database_name` and `database_id`.
 14. Go to `drizzle.config.ts` and change db name in `dbName`.
 15. Go to `package.json` and change db name in `db:push:*` and `db:backup:prod`.
-16. Generate and migrate the schema to dev or prod db: `bun run db:migrate; bun run db:push:dev; bun run db:push:prod`
-17. Develop on local with `bun run dev` 
-18. Deploy to prod  with `bun run deploy` 
-
+16. Generate and migrate the schema to dev or prod db: `bun run db:migrate; bun run db:push:dev; bun run db:push:prod`.
+17. Develop on local with `bun run dev`.
+18. Deploy to prod  with `bun run deploy`.

--- a/README.md
+++ b/README.md
@@ -35,18 +35,20 @@
 
 1. Install prerequisites Node.js or Bun `curl -fsSL https://bun.sh/install | bash`
 2. Clone to localhost or server `git clone https://github.com/vtempest/docs-stack-starter`
-3. `mv .env.example .env ; mv wrangler.example.toml wrangler.toml` and set the domain and API keys in `.env` 
-4. Auth providers, get id/secret from [Google](https://console.cloud.google.com/apis/credentials) 
-5. Set OAuth origin `http://localhost` and `http://localhost:5173` on local or `https://domain.com` on server
-6. Set redirect `http://localhost:5173/auth/oauth/google/callback` or `https://api.domain.com/auth/oauth/google/callback`
-7. For email auth, get API from [Resend](https://resend.com/api-keys) mailer and verify domain
-8. Log in with your Cloudflare account by running: `bunx wrangler login`
-9. Create your D1 database via dashboard or with `bunx wrangler d1 create my-db-prod`
-10. Copy the console output database_name and database_id
-11. Go to `wrangler.toml` and change `database_name` and `database_id`.
-12. Go to `drizzle.config.ts` and change db name in `dbName`.
-13. Go to `package.json` and change db name in `db:push:*`.
-14. Generate and migrate the schema to dev or prod db: `bun run db:migrate; bun run db:push:dev; bun run db:push:prod`
-15. Develop on local with `bun run dev` 
-16. Deploy to prod  with `bun run deploy` 
+3. CD to project directory `cd docs-stack-starter`
+4. Install dependencies `bun install`
+5. `mv .env.example .env ; mv wrangler.example.toml wrangler.toml` and set the domain and API keys in `.env` 
+6. Auth providers, get id/secret from [Google](https://console.cloud.google.com/apis/credentials) 
+7. Set OAuth origin `http://localhost` and `http://localhost:5173` on local or `https://domain.com` on server
+8. Set redirect `http://localhost:5173/auth/oauth/google/callback` or `https://api.domain.com/auth/oauth/google/callback`
+9. For email auth, get API from [Resend](https://resend.com/api-keys) mailer and verify domain
+10. Log in with your Cloudflare account by running: `bunx wrangler login`
+11. Create your D1 database via dashboard or with `bunx wrangler d1 create my-db-prod`
+12. Copy the console output database_name and database_id
+13. Go to `wrangler.toml` and change `database_name` and `database_id`.
+14. Go to `drizzle.config.ts` and change db name in `dbName`.
+15. Go to `package.json` and change db name in `db:push:*`.
+16. Generate and migrate the schema to dev or prod db: `bun run db:migrate; bun run db:push:dev; bun run db:push:prod`
+17. Develop on local with `bun run dev` 
+18. Deploy to prod  with `bun run deploy` 
 


### PR DESCRIPTION
I just went through the process of trying out [Serverless-DOCS-Stack](https://github.com/vtempest/Serverless-DOCS-Stack) as a test and noticed a couple of small things in the README that could be changed to help others using this template:

1. Missing instruction to `cd` into folder of cloned repo
2. Missing instruction to modify script in `packages.json` for backing up the database (`db:backup:prod`)

Less important but I also noticed that there were periods at the end of a few of the steps but not all of them so I added periods to the end of the rest to make it more uniform (OCD I know lol).